### PR TITLE
fix: isolate log context fields to prevent upstream leakage

### DIFF
--- a/loggers/fields.go
+++ b/loggers/fields.go
@@ -31,15 +31,18 @@ func (o *LogFields) Del(key string) {
 // AddToLogContext adds log fields to context.
 // Any info added here will be added to all logs using this context
 func AddToLogContext(ctx context.Context, key string, value interface{}) context.Context {
-	data := FromContext(ctx)
-	if data == nil {
-		ctx = context.WithValue(ctx, contextKey, new(LogFields))
-		data = FromContext(ctx)
+	existingFields := FromContext(ctx)
+	newFields := &LogFields{}
+
+	if existingFields != nil {
+		existingFields.Range(func(key, value interface{}) bool {
+			newFields.Add(key.(string), value)
+			return true
+		})
 	}
-	if data != nil {
-		data.Add(key, value)
-	}
-	return ctx
+
+	newFields.Add(key, value)
+	return context.WithValue(ctx, contextKey, newFields)
 }
 
 // FromContext fetchs log fields from provided context


### PR DESCRIPTION
Refactored AddToLogContext to clone existing log fields instead of mutating them directly. This ensures that log context updates do not affect parent or sibling contexts, preventing unintended key propagation to upstream callers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how log fields are handled in the application to prevent unintended changes to existing log data when adding new log entries. This ensures more reliable and predictable logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->