### PR TITLE
feat: add log.AddToContext convenience wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ this package is based on https://github.com/carousell/Orion/tree/master/utils/lo
 
 ## Index
 
+- [func AddToContext\(ctx context.Context, key string, value any\) context.Context](<#AddToContext>)
 - [func Debug\(ctx context.Context, args ...any\)](<#Debug>)
 - [func Error\(ctx context.Context, args ...any\)](<#Error>)
 - [func GetLevel\(\) loggers.Level](<#GetLevel>)
@@ -63,6 +64,15 @@ this package is based on https://github.com/carousell/Orion/tree/master/utils/lo
   - [func GetLogger\(\) Logger](<#GetLogger>)
   - [func NewLogger\(log loggers.BaseLogger\) Logger](<#NewLogger>)
 
+
+<a name="AddToContext"></a>
+## func AddToContext
+
+```go
+func AddToContext(ctx context.Context, key string, value any) context.Context
+```
+
+AddToContext adds log fields to the provided context. Any info added here will be included in all logs that use the returned context. This is the preferred entry point for adding contextual logging fields and is implemented internally using loggers.AddToLogContext.
 
 <a name="Debug"></a>
 ## func Debug

--- a/log.go
+++ b/log.go
@@ -78,3 +78,10 @@ func SetLogger(l Logger) {
 		defaultLogger.Store(&l)
 	}
 }
+
+// AddToContext adds log fields to context.
+// Any info added here will be added to all logs using this context.
+// This is a convenience wrapper around loggers.AddToLogContext.
+func AddToContext(ctx context.Context, key string, value any) context.Context {
+	return loggers.AddToLogContext(ctx, key, value)
+}

--- a/log.go
+++ b/log.go
@@ -79,9 +79,13 @@ func SetLogger(l Logger) {
 	}
 }
 
-// AddToContext adds log fields to context.
-// Any info added here will be added to all logs using this context.
-// This is a convenience wrapper around loggers.AddToLogContext.
+// AddToContext adds log fields to the provided context.
+// Any info added here will be included in all logs that use the returned context.
+// This is the preferred entry point for adding contextual logging fields and is implemented
+// internally using loggers.AddToLogContext.
 func AddToContext(ctx context.Context, key string, value any) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	return loggers.AddToLogContext(ctx, key, value)
 }


### PR DESCRIPTION
## Summary
- Add `log.AddToContext(ctx, key, value)` that delegates to `loggers.AddToLogContext` so callers don't need to import the `loggers` sub-package directly

## Test plan
- [x] Existing tests pass (`make test`)
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a logging context helper function that enables easier enrichment of operations with contextual log fields, improving logging flexibility and consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->