### PR TITLE
feat: add SupportPackageIsVersion1 compile-time version sentinel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/go-coldbrew/log
 go 1.25.8
 
 require (
-	github.com/go-coldbrew/options v0.2.4
+	github.com/go-coldbrew/options v0.2.6
 	github.com/go-kit/log v0.2.1
 	github.com/sirupsen/logrus v1.9.4
 	go.uber.org/zap v1.27.1
@@ -162,7 +162,6 @@ require (
 	github.com/nishanths/exhaustive v0.12.0 // indirect
 	github.com/nishanths/predeclared v0.2.2 // indirect
 	github.com/nunnatsa/ginkgolinter v0.23.0 // indirect
-	github.com/nxadm/tail v1.4.11 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
@@ -242,6 +241,7 @@ require (
 	golang.org/x/vuln v1.1.4 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/ghostiam/protogetter v0.3.20 h1:oW7OPFit2FxZOpmMRPP9FffU4uUpfeE/rEdE1
 github.com/ghostiam/protogetter v0.3.20/go.mod h1:FjIu5Yfs6FT391m+Fjp3fbAYJ6rkL/J6ySpZBfnODuI=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
 github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
-github.com/go-coldbrew/options v0.2.4 h1:aGcjQWhXjibRRN1XVc3mzz2IAKxNlVC4+xyhrGnSRKg=
-github.com/go-coldbrew/options v0.2.4/go.mod h1:RstwV0WeRJyUN2/P7M0l67LTsLeUfCXkaLU2LrXRx7M=
+github.com/go-coldbrew/options v0.2.6 h1:Nr93v7PbO+EYLHhzA8biGumaTTSHLHqTYLg70n/foXE=
+github.com/go-coldbrew/options v0.2.6/go.mod h1:Os4pZwIgMHES079iOKXTlzcipWXbxw0OhsAN5D9m2mM=
 github.com/go-critic/go-critic v0.14.3 h1:5R1qH2iFeo4I/RJU8vTezdqs08Egi4u5p6vOESA0pog=
 github.com/go-critic/go-critic v0.14.3/go.mod h1:xwntfW6SYAd7h1OqDzmN6hBX/JxsEKl5up/Y2bsxgVQ=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=

--- a/log.go
+++ b/log.go
@@ -8,6 +8,10 @@ import (
 	"github.com/go-coldbrew/log/loggers/gokit"
 )
 
+// SupportPackageIsVersion1 is a compile-time assertion constant.
+// Downstream packages reference this to enforce version compatibility.
+const SupportPackageIsVersion1 = true
+
 var defaultLogger atomic.Pointer[Logger]
 
 type logger struct {

--- a/options.go
+++ b/options.go
@@ -7,6 +7,9 @@ import (
 	"github.com/go-coldbrew/options"
 )
 
+// Compile-time version compatibility check.
+var _ = options.SupportPackageIsVersion1
+
 const logLevelKey = "OverrideLogLevel"
 
 // OverrideLogLevel allows the default log level to be overridden from request context


### PR DESCRIPTION
## Summary
- Add `SupportPackageIsVersion1` constant following the gRPC `SupportPackageIsVersion` pattern
- Reference upstream package sentinels to enforce version compatibility at compile time
- When a breaking change is made, export a new version and remove the old one to force coordinated updates

## Test plan
- [x] `go build ./...` passes (with updated upstream dependencies)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated key dependencies to newer compatible versions, improving overall stability and long-term compatibility.
  * Implemented internal version compatibility verification to ensure seamless integration and proper functionality with dependent modules.
  * Optimized the module's dependency structure to enhance maintainability and reduce potential version-related conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->