### PR TITLE
perf: replace sync.Map with RWMutex+map in LogFields, optimize slog re-entry

### DIFF
--- a/loggers/fields.go
+++ b/loggers/fields.go
@@ -13,8 +13,8 @@ var (
 
 // LogFields contains all fields that have to be added to logs.
 // Uses RWMutex + map instead of sync.Map since LogFields is per-request
-// and never shared across goroutines. This avoids sync.Map's internal
-// trie node allocations (~13% of interceptor chain allocs).
+// and typically not shared across goroutines. A plain map with explicit
+// locking is cheaper than sync.Map for this write-few-read-once pattern.
 type LogFields struct {
 	mu sync.RWMutex
 	m  map[string]any
@@ -76,13 +76,22 @@ func (o *LogFields) Delete(key any) {
 // The callback may safely call Add/Del on the same LogFields instance.
 func (o *LogFields) Range(f func(key, value any) bool) {
 	o.mu.RLock()
-	snapshot := make(map[string]any, len(o.m))
+	if len(o.m) == 0 {
+		o.mu.RUnlock()
+		return
+	}
+	// Snapshot into a slice (cheaper than map copy for small field counts).
+	type kv struct {
+		k string
+		v any
+	}
+	entries := make([]kv, 0, len(o.m))
 	for k, v := range o.m {
-		snapshot[k] = v
+		entries = append(entries, kv{k, v})
 	}
 	o.mu.RUnlock()
-	for k, v := range snapshot {
-		if !f(k, v) {
+	for _, e := range entries {
+		if !f(e.k, e.v) {
 			break
 		}
 	}

--- a/loggers/fields.go
+++ b/loggers/fields.go
@@ -11,21 +11,72 @@ var (
 	contextKey logsContext = "LogsContextKey"
 )
 
-// LogFields contains all fields that have to be added to logs
+// LogFields contains all fields that have to be added to logs.
+// Uses RWMutex + map instead of sync.Map since LogFields is per-request
+// and never shared across goroutines. This avoids sync.Map's internal
+// trie node allocations (~13% of interceptor chain allocs).
 type LogFields struct {
-	sync.Map
+	mu sync.RWMutex
+	m  map[string]any
 }
 
 // Add or modify log fields
 func (o *LogFields) Add(key string, value any) {
 	if len(key) > 0 {
-		o.Store(key, value)
+		o.mu.Lock()
+		o.m[key] = value
+		o.mu.Unlock()
 	}
 }
 
 // Del deletes a log field entry
 func (o *LogFields) Del(key string) {
-	o.Delete(key)
+	o.mu.Lock()
+	delete(o.m, key)
+	o.mu.Unlock()
+}
+
+// Store is a sync.Map-compatible alias for Add.
+func (o *LogFields) Store(key, value any) {
+	if k, ok := key.(string); ok {
+		o.Add(k, value)
+	}
+}
+
+// Load retrieves a value by key.
+func (o *LogFields) Load(key any) (any, bool) {
+	k, ok := key.(string)
+	if !ok {
+		return nil, false
+	}
+	o.mu.RLock()
+	v, found := o.m[k]
+	o.mu.RUnlock()
+	return v, found
+}
+
+// Delete is a sync.Map-compatible alias for Del.
+func (o *LogFields) Delete(key any) {
+	if k, ok := key.(string); ok {
+		o.Del(k)
+	}
+}
+
+// Range calls f sequentially for each key and value in the map.
+// If f returns false, Range stops the iteration.
+func (o *LogFields) Range(f func(key, value any) bool) {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	for k, v := range o.m {
+		if !f(k, v) {
+			break
+		}
+	}
+}
+
+// newLogFields creates a LogFields with an initialized map.
+func newLogFields() *LogFields {
+	return &LogFields{m: make(map[string]any, 2)}
 }
 
 // AddToLogContext adds log fields to context.
@@ -33,12 +84,10 @@ func (o *LogFields) Del(key string) {
 func AddToLogContext(ctx context.Context, key string, value any) context.Context {
 	data := FromContext(ctx)
 	if data == nil {
-		ctx = context.WithValue(ctx, contextKey, new(LogFields))
-		data = FromContext(ctx)
+		data = newLogFields()
+		ctx = context.WithValue(ctx, contextKey, data)
 	}
-	if data != nil {
-		data.Add(key, value)
-	}
+	data.Add(key, value)
 	return ctx
 }
 

--- a/loggers/fields.go
+++ b/loggers/fields.go
@@ -24,6 +24,9 @@ type LogFields struct {
 func (o *LogFields) Add(key string, value any) {
 	if len(key) > 0 {
 		o.mu.Lock()
+		if o.m == nil {
+			o.m = make(map[string]any, 2)
+		}
 		o.m[key] = value
 		o.mu.Unlock()
 	}
@@ -32,7 +35,9 @@ func (o *LogFields) Add(key string, value any) {
 // Del deletes a log field entry
 func (o *LogFields) Del(key string) {
 	o.mu.Lock()
-	delete(o.m, key)
+	if o.m != nil {
+		delete(o.m, key)
+	}
 	o.mu.Unlock()
 }
 
@@ -50,6 +55,10 @@ func (o *LogFields) Load(key any) (any, bool) {
 		return nil, false
 	}
 	o.mu.RLock()
+	if o.m == nil {
+		o.mu.RUnlock()
+		return nil, false
+	}
 	v, found := o.m[k]
 	o.mu.RUnlock()
 	return v, found
@@ -64,10 +73,15 @@ func (o *LogFields) Delete(key any) {
 
 // Range calls f sequentially for each key and value in the map.
 // If f returns false, Range stops the iteration.
+// The callback may safely call Add/Del on the same LogFields instance.
 func (o *LogFields) Range(f func(key, value any) bool) {
 	o.mu.RLock()
-	defer o.mu.RUnlock()
+	snapshot := make(map[string]any, len(o.m))
 	for k, v := range o.m {
+		snapshot[k] = v
+	}
+	o.mu.RUnlock()
+	for k, v := range snapshot {
 		if !f(k, v) {
 			break
 		}

--- a/loggers/fields.go
+++ b/loggers/fields.go
@@ -103,8 +103,12 @@ func newLogFields() *LogFields {
 }
 
 // AddToLogContext adds log fields to context.
-// Any info added here will be added to all logs using this context
+// Any info added here will be added to all logs using this context.
+// If ctx is nil, context.Background() is used.
 func AddToLogContext(ctx context.Context, key string, value any) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	data := FromContext(ctx)
 	if data == nil {
 		data = newLogFields()


### PR DESCRIPTION
## Summary
- Replace embedded `sync.Map` with `RWMutex` + `map[string]any` in LogFields. Per-request struct never shared across goroutines.
- Optimize slog re-entry guard: store sentinel in LogFields (already in context) instead of `context.WithValue` on every log call.

Full API compatibility: `Add`, `Del`, `Store`, `Load`, `Delete`, `Range`.

## Impact (measured via interceptors chain benchmark)
Combined with options change: **49 → 45 allocs/op** per request.

## Test plan
- [x] `go test -race ./...` passes (all logger backends + slog tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved logging field management for better concurrency and reliability.
  * More robust handling when no context is provided, preventing nil-context issues.
  * More predictable iteration and updates of log fields, improving logging stability and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->