### PR TITLE
test: verify slog re-entry guard prevents infinite loops

### DIFF
--- a/loggers/slog/slog_test.go
+++ b/loggers/slog/slog_test.go
@@ -461,3 +461,62 @@ func keys(m map[string]any) []string {
 	}
 	return ks
 }
+
+// reentrantHandler is a slog.Handler that logs again when handling a record,
+// triggering the re-entry guard.
+type reentrantHandler struct {
+	inner  slog.Handler
+	logger loggers.BaseLogger
+	count  int
+}
+
+func (h *reentrantHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.inner.Enabled(ctx, level)
+}
+
+func (h *reentrantHandler) Handle(ctx context.Context, record slog.Record) error {
+	h.count++
+	if h.count <= 1 && h.logger != nil {
+		// Trigger re-entry: log again from inside the handler
+		h.logger.Log(ctx, loggers.InfoLevel, 1, "msg", "re-entrant log")
+	}
+	return h.inner.Handle(ctx, record)
+}
+
+func (h *reentrantHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &reentrantHandler{inner: h.inner.WithAttrs(attrs), logger: h.logger}
+}
+
+func (h *reentrantHandler) WithGroup(name string) slog.Handler {
+	return &reentrantHandler{inner: h.inner.WithGroup(name), logger: h.logger}
+}
+
+func TestSlogReentryGuard(t *testing.T) {
+	var buf bytes.Buffer
+	inner := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	rh := &reentrantHandler{inner: inner}
+
+	lgr := NewLoggerWithHandler(rh, loggers.WithLevel(loggers.DebugLevel))
+	rh.logger = lgr // wire the re-entry trigger
+
+	// This should NOT infinite-loop thanks to the re-entry guard.
+	// The guard uses context.WithValue(slogBackendKey{}) to detect re-entry.
+	done := make(chan struct{})
+	go func() {
+		lgr.Log(context.Background(), loggers.InfoLevel, 0, "msg", "trigger")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success: no infinite loop
+	case <-time.After(2 * time.Second):
+		t.Fatal("slog re-entry guard failed: infinite loop detected")
+	}
+
+	// Verify only the outer log was written (re-entrant call should be dropped)
+	output := buf.String()
+	if output == "" {
+		t.Error("expected at least one log line")
+	}
+}

--- a/loggers/slog/slog_test.go
+++ b/loggers/slog/slog_test.go
@@ -476,8 +476,9 @@ func (h *reentrantHandler) Enabled(ctx context.Context, level slog.Level) bool {
 
 func (h *reentrantHandler) Handle(ctx context.Context, record slog.Record) error {
 	h.count++
-	if h.count <= 1 && h.logger != nil {
-		// Trigger re-entry: log again from inside the handler
+	if h.logger != nil {
+		// Always trigger re-entry — the slog re-entry guard is what
+		// prevents infinite recursion. Without the guard, this would loop forever.
 		h.logger.Log(ctx, loggers.InfoLevel, 1, "msg", "re-entrant log")
 	}
 	return h.inner.Handle(ctx, record)
@@ -514,9 +515,18 @@ func TestSlogReentryGuard(t *testing.T) {
 		t.Fatal("slog re-entry guard failed: infinite loop detected")
 	}
 
-	// Verify only the outer log was written (re-entrant call should be dropped)
+	// Parse JSON output and verify exactly one log record was written.
+	// The re-entrant "re-entrant log" call should be dropped by the guard.
 	output := buf.String()
-	if output == "" {
-		t.Error("expected at least one log line")
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected exactly 1 log line, got %d: %s", len(lines), output)
+	}
+	var record map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &record); err != nil {
+		t.Fatalf("failed to parse log JSON: %v", err)
+	}
+	if msg, ok := record["msg"].(string); !ok || msg != "trigger" {
+		t.Errorf("expected msg='trigger', got %v", record["msg"])
 	}
 }

--- a/loggers/slog/slog_test.go
+++ b/loggers/slog/slog_test.go
@@ -467,7 +467,6 @@ func keys(m map[string]any) []string {
 type reentrantHandler struct {
 	inner  slog.Handler
 	logger loggers.BaseLogger
-	count  int
 }
 
 func (h *reentrantHandler) Enabled(ctx context.Context, level slog.Level) bool {
@@ -475,7 +474,6 @@ func (h *reentrantHandler) Enabled(ctx context.Context, level slog.Level) bool {
 }
 
 func (h *reentrantHandler) Handle(ctx context.Context, record slog.Record) error {
-	h.count++
 	if h.logger != nil {
 		// Always trigger re-entry — the slog re-entry guard is what
 		// prevents infinite recursion. Without the guard, this would loop forever.


### PR DESCRIPTION
## Summary
`TestSlogReentryGuard` uses a custom `reentrantHandler` that always logs again from inside `Handle()`, triggering the re-entry guard. Verifies:
- No infinite loop (2-second timeout)
- Exactly one log record is written (outer log only)
- The re-entrant call is silently dropped (parsed JSON, asserted `msg=trigger`)

Partial coverage for #22 — concurrent logging from the same context remains as future work.

## Test plan
- [x] `go test -race ./...` passes