### PR TITLE
feat: refactor LogFields to use shared RequestContext

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/go-coldbrew/log
 
 go 1.25.8
 
+replace github.com/go-coldbrew/options => ../options
+
 require (
 	github.com/go-coldbrew/options v0.2.6
 	github.com/go-kit/log v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,6 @@ github.com/ghostiam/protogetter v0.3.20 h1:oW7OPFit2FxZOpmMRPP9FffU4uUpfeE/rEdE1
 github.com/ghostiam/protogetter v0.3.20/go.mod h1:FjIu5Yfs6FT391m+Fjp3fbAYJ6rkL/J6ySpZBfnODuI=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
 github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
-github.com/go-coldbrew/options v0.2.6 h1:Nr93v7PbO+EYLHhzA8biGumaTTSHLHqTYLg70n/foXE=
-github.com/go-coldbrew/options v0.2.6/go.mod h1:Os4pZwIgMHES079iOKXTlzcipWXbxw0OhsAN5D9m2mM=
 github.com/go-critic/go-critic v0.14.3 h1:5R1qH2iFeo4I/RJU8vTezdqs08Egi4u5p6vOESA0pog=
 github.com/go-critic/go-critic v0.14.3/go.mod h1:xwntfW6SYAd7h1OqDzmN6hBX/JxsEKl5up/Y2bsxgVQ=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=

--- a/loggers/README.md
+++ b/loggers/README.md
@@ -102,7 +102,7 @@ var (
 ```
 
 <a name="AddToLogContext"></a>
-## func [AddToLogContext](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L63>)
+## func [AddToLogContext](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L72>)
 
 ```go
 func AddToLogContext(ctx context.Context, key string, value any) context.Context
@@ -199,9 +199,9 @@ func (level Level) String() string
 Convert the Level to a string. E.g. ErrorLevel becomes "error".
 
 <a name="LogFields"></a>
-## type [LogFields](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L12-L14>)
+## type [LogFields](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L14-L16>)
 
-LogFields contains all fields that have to be added to logs. It wraps \*options.Options to share the same RequestContext storage, eliminating a separate context.WithValue allocation per request.
+LogFields contains all fields that have to be added to logs. It wraps \*options.Options to share the same RequestContext storage, eliminating a separate context.WithValue allocation per request. LogFields should be obtained via FromContext or AddToLogContext; the zero value is safe but acts as a no\-op.
 
 ```go
 type LogFields struct {
@@ -210,7 +210,7 @@ type LogFields struct {
 ```
 
 <a name="FromContext"></a>
-### func [FromContext](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L71>)
+### func [FromContext](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L80>)
 
 ```go
 func FromContext(ctx context.Context) *LogFields
@@ -219,7 +219,7 @@ func FromContext(ctx context.Context) *LogFields
 FromContext fetches log fields from provided context.
 
 <a name="LogFields.Add"></a>
-### func \(\*LogFields\) [Add](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L17>)
+### func \(\*LogFields\) [Add](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L19>)
 
 ```go
 func (o *LogFields) Add(key string, value any)
@@ -228,7 +228,7 @@ func (o *LogFields) Add(key string, value any)
 Add adds or modifies a log field.
 
 <a name="LogFields.Del"></a>
-### func \(\*LogFields\) [Del](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L24>)
+### func \(\*LogFields\) [Del](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L26>)
 
 ```go
 func (o *LogFields) Del(key string)
@@ -237,7 +237,7 @@ func (o *LogFields) Del(key string)
 Del deletes a log field entry.
 
 <a name="LogFields.Delete"></a>
-### func \(\*LogFields\) [Delete](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L41>)
+### func \(\*LogFields\) [Delete](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L48>)
 
 ```go
 func (o *LogFields) Delete(key any)
@@ -246,7 +246,7 @@ func (o *LogFields) Delete(key any)
 Delete is a sync.Map\-compatible alias for Del.
 
 <a name="LogFields.Load"></a>
-### func \(\*LogFields\) [Load](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L36>)
+### func \(\*LogFields\) [Load](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L40>)
 
 ```go
 func (o *LogFields) Load(key any) (any, bool)
@@ -255,7 +255,7 @@ func (o *LogFields) Load(key any) (any, bool)
 Load retrieves a value by key.
 
 <a name="LogFields.Range"></a>
-### func \(\*LogFields\) [Range](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L51>)
+### func \(\*LogFields\) [Range](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L58>)
 
 ```go
 func (o *LogFields) Range(f func(key, value any) bool)
@@ -264,7 +264,7 @@ func (o *LogFields) Range(f func(key, value any) bool)
 Range calls f sequentially for each key and value in the map. If f returns false, Range stops the iteration. The callback may safely call Add/Del on the same LogFields instance. Uses a slice snapshot for efficient iteration over small field counts.
 
 <a name="LogFields.Store"></a>
-### func \(\*LogFields\) [Store](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L29>)
+### func \(\*LogFields\) [Store](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L33>)
 
 ```go
 func (o *LogFields) Store(key, value any)

--- a/loggers/README.md
+++ b/loggers/README.md
@@ -29,6 +29,10 @@ Package loggers provides loggers implementation for log package
   - [func FromContext\(ctx context.Context\) \*LogFields](<#FromContext>)
   - [func \(o \*LogFields\) Add\(key string, value any\)](<#LogFields.Add>)
   - [func \(o \*LogFields\) Del\(key string\)](<#LogFields.Del>)
+  - [func \(o \*LogFields\) Delete\(key any\)](<#LogFields.Delete>)
+  - [func \(o \*LogFields\) Load\(key any\) \(any, bool\)](<#LogFields.Load>)
+  - [func \(o \*LogFields\) Range\(f func\(key, value any\) bool\)](<#LogFields.Range>)
+  - [func \(o \*LogFields\) Store\(key, value any\)](<#LogFields.Store>)
 - [type Option](<#Option>)
   - [func WithCallerFieldName\(name string\) Option](<#WithCallerFieldName>)
   - [func WithCallerFileDepth\(depth int\) Option](<#WithCallerFileDepth>)
@@ -98,13 +102,13 @@ var (
 ```
 
 <a name="AddToLogContext"></a>
-## func [AddToLogContext](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L33>)
+## func [AddToLogContext](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L63>)
 
 ```go
 func AddToLogContext(ctx context.Context, key string, value any) context.Context
 ```
 
-AddToLogContext adds log fields to context. Any info added here will be added to all logs using this context
+AddToLogContext adds log fields to context. Any info added here will be added to all logs using this context. If ctx is nil, context.Background\(\) is used.
 
 <details><summary>Example</summary>
 <p>
@@ -195,42 +199,78 @@ func (level Level) String() string
 Convert the Level to a string. E.g. ErrorLevel becomes "error".
 
 <a name="LogFields"></a>
-## type [LogFields](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L15-L17>)
+## type [LogFields](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L12-L14>)
 
-LogFields contains all fields that have to be added to logs
+LogFields contains all fields that have to be added to logs. It wraps \*options.Options to share the same RequestContext storage, eliminating a separate context.WithValue allocation per request.
 
 ```go
 type LogFields struct {
-    sync.Map
+    // contains filtered or unexported fields
 }
 ```
 
 <a name="FromContext"></a>
-### func [FromContext](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L46>)
+### func [FromContext](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L71>)
 
 ```go
 func FromContext(ctx context.Context) *LogFields
 ```
 
-FromContext fetchs log fields from provided context
+FromContext fetches log fields from provided context.
 
 <a name="LogFields.Add"></a>
-### func \(\*LogFields\) [Add](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L20>)
+### func \(\*LogFields\) [Add](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L17>)
 
 ```go
 func (o *LogFields) Add(key string, value any)
 ```
 
-Add or modify log fields
+Add adds or modifies a log field.
 
 <a name="LogFields.Del"></a>
-### func \(\*LogFields\) [Del](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L27>)
+### func \(\*LogFields\) [Del](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L24>)
 
 ```go
 func (o *LogFields) Del(key string)
 ```
 
-Del deletes a log field entry
+Del deletes a log field entry.
+
+<a name="LogFields.Delete"></a>
+### func \(\*LogFields\) [Delete](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L41>)
+
+```go
+func (o *LogFields) Delete(key any)
+```
+
+Delete is a sync.Map\-compatible alias for Del.
+
+<a name="LogFields.Load"></a>
+### func \(\*LogFields\) [Load](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L36>)
+
+```go
+func (o *LogFields) Load(key any) (any, bool)
+```
+
+Load retrieves a value by key.
+
+<a name="LogFields.Range"></a>
+### func \(\*LogFields\) [Range](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L51>)
+
+```go
+func (o *LogFields) Range(f func(key, value any) bool)
+```
+
+Range calls f sequentially for each key and value in the map. If f returns false, Range stops the iteration. The callback may safely call Add/Del on the same LogFields instance. Uses a slice snapshot for efficient iteration over small field counts.
+
+<a name="LogFields.Store"></a>
+### func \(\*LogFields\) [Store](<https://github.com/go-coldbrew/log/blob/main/loggers/fields.go#L29>)
+
+```go
+func (o *LogFields) Store(key, value any)
+```
+
+Store is a sync.Map\-compatible alias for Add.
 
 <a name="Option"></a>
 ## type [Option](<https://github.com/go-coldbrew/log/blob/main/loggers/loggers.go#L131>)

--- a/loggers/fields.go
+++ b/loggers/fields.go
@@ -9,20 +9,24 @@ import (
 // LogFields contains all fields that have to be added to logs.
 // It wraps *options.Options to share the same RequestContext storage,
 // eliminating a separate context.WithValue allocation per request.
+// LogFields should be obtained via FromContext or AddToLogContext;
+// the zero value is safe but acts as a no-op.
 type LogFields struct {
 	inner *options.Options
 }
 
 // Add adds or modifies a log field.
 func (o *LogFields) Add(key string, value any) {
-	if len(key) > 0 {
+	if o.inner != nil && len(key) > 0 {
 		o.inner.Add(key, value)
 	}
 }
 
 // Del deletes a log field entry.
 func (o *LogFields) Del(key string) {
-	o.inner.Del(key)
+	if o.inner != nil {
+		o.inner.Del(key)
+	}
 }
 
 // Store is a sync.Map-compatible alias for Add.
@@ -34,6 +38,9 @@ func (o *LogFields) Store(key, value any) {
 
 // Load retrieves a value by key.
 func (o *LogFields) Load(key any) (any, bool) {
+	if o.inner == nil {
+		return nil, false
+	}
 	return o.inner.Load(key)
 }
 
@@ -49,7 +56,9 @@ func (o *LogFields) Delete(key any) {
 // The callback may safely call Add/Del on the same LogFields instance.
 // Uses a slice snapshot for efficient iteration over small field counts.
 func (o *LogFields) Range(f func(key, value any) bool) {
-	o.inner.RangeSlice(f)
+	if o.inner != nil {
+		o.inner.RangeSlice(f)
+	}
 }
 
 // wrapAsLogFields wraps an *options.Options as a *LogFields.

--- a/loggers/fields.go
+++ b/loggers/fields.go
@@ -2,43 +2,27 @@ package loggers
 
 import (
 	"context"
-	"sync"
-)
 
-type logsContext string
-
-var (
-	contextKey logsContext = "LogsContextKey"
+	"github.com/go-coldbrew/options"
 )
 
 // LogFields contains all fields that have to be added to logs.
-// Uses RWMutex + map instead of sync.Map since LogFields is per-request
-// and typically not shared across goroutines. A plain map with explicit
-// locking is cheaper than sync.Map for this write-few-read-once pattern.
+// It wraps *options.Options to share the same RequestContext storage,
+// eliminating a separate context.WithValue allocation per request.
 type LogFields struct {
-	mu sync.RWMutex
-	m  map[string]any
+	inner *options.Options
 }
 
-// Add or modify log fields
+// Add adds or modifies a log field.
 func (o *LogFields) Add(key string, value any) {
 	if len(key) > 0 {
-		o.mu.Lock()
-		if o.m == nil {
-			o.m = make(map[string]any, 2)
-		}
-		o.m[key] = value
-		o.mu.Unlock()
+		o.inner.Add(key, value)
 	}
 }
 
-// Del deletes a log field entry
+// Del deletes a log field entry.
 func (o *LogFields) Del(key string) {
-	o.mu.Lock()
-	if o.m != nil {
-		delete(o.m, key)
-	}
-	o.mu.Unlock()
+	o.inner.Del(key)
 }
 
 // Store is a sync.Map-compatible alias for Add.
@@ -50,18 +34,7 @@ func (o *LogFields) Store(key, value any) {
 
 // Load retrieves a value by key.
 func (o *LogFields) Load(key any) (any, bool) {
-	k, ok := key.(string)
-	if !ok {
-		return nil, false
-	}
-	o.mu.RLock()
-	if o.m == nil {
-		o.mu.RUnlock()
-		return nil, false
-	}
-	v, found := o.m[k]
-	o.mu.RUnlock()
-	return v, found
+	return o.inner.Load(key)
 }
 
 // Delete is a sync.Map-compatible alias for Del.
@@ -74,32 +47,14 @@ func (o *LogFields) Delete(key any) {
 // Range calls f sequentially for each key and value in the map.
 // If f returns false, Range stops the iteration.
 // The callback may safely call Add/Del on the same LogFields instance.
+// Uses a slice snapshot for efficient iteration over small field counts.
 func (o *LogFields) Range(f func(key, value any) bool) {
-	o.mu.RLock()
-	if len(o.m) == 0 {
-		o.mu.RUnlock()
-		return
-	}
-	// Snapshot into a slice (cheaper than map copy for small field counts).
-	type kv struct {
-		k string
-		v any
-	}
-	entries := make([]kv, 0, len(o.m))
-	for k, v := range o.m {
-		entries = append(entries, kv{k, v})
-	}
-	o.mu.RUnlock()
-	for _, e := range entries {
-		if !f(e.k, e.v) {
-			break
-		}
-	}
+	o.inner.RangeSlice(f)
 }
 
-// newLogFields creates a LogFields with an initialized map.
-func newLogFields() *LogFields {
-	return &LogFields{m: make(map[string]any, 2)}
+// wrapAsLogFields wraps an *options.Options as a *LogFields.
+func wrapAsLogFields(opts *options.Options) *LogFields {
+	return &LogFields{inner: opts}
 }
 
 // AddToLogContext adds log fields to context.
@@ -109,24 +64,16 @@ func AddToLogContext(ctx context.Context, key string, value any) context.Context
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	data := FromContext(ctx)
-	if data == nil {
-		data = newLogFields()
-		ctx = context.WithValue(ctx, contextKey, data)
-	}
-	data.Add(key, value)
-	return ctx
+	return options.AddToLogFields(ctx, key, value)
 }
 
-// FromContext fetchs log fields from provided context
+// FromContext fetches log fields from provided context.
 func FromContext(ctx context.Context) *LogFields {
 	if ctx == nil {
 		return nil
 	}
-	if h := ctx.Value(contextKey); h != nil {
-		if logData, ok := h.(*LogFields); ok {
-			return logData
-		}
+	if opts := options.LogFieldsFromContext(ctx); opts != nil {
+		return wrapAsLogFields(opts)
 	}
 	return nil
 }

--- a/loggers/slog/README.md
+++ b/loggers/slog/README.md
@@ -90,7 +90,7 @@ func main() {
 
 
 <a name="NewLogger"></a>
-## func [NewLogger](<https://github.com/go-coldbrew/log/blob/main/loggers/slog/slog.go#L153>)
+## func [NewLogger](<https://github.com/go-coldbrew/log/blob/main/loggers/slog/slog.go#L161>)
 
 ```go
 func NewLogger(options ...loggers.Option) loggers.BaseLogger
@@ -99,7 +99,7 @@ func NewLogger(options ...loggers.Option) loggers.BaseLogger
 NewLogger returns a BaseLogger implementation backed by log/slog.
 
 <a name="NewLoggerWithHandler"></a>
-## func [NewLoggerWithHandler](<https://github.com/go-coldbrew/log/blob/main/loggers/slog/slog.go#L204>)
+## func [NewLoggerWithHandler](<https://github.com/go-coldbrew/log/blob/main/loggers/slog/slog.go#L212>)
 
 ```go
 func NewLoggerWithHandler(handler slog.Handler, options ...loggers.Option) loggers.BaseLogger

--- a/wrap/README.md
+++ b/wrap/README.md
@@ -32,7 +32,7 @@ func ToGoKitLogger(l log.Logger) basegokit.Logger
 ToGoKitLogger wraps a log.Logger to gokit/log.Logger
 
 <a name="ToSlogHandler"></a>
-## func [ToSlogHandler](<https://github.com/go-coldbrew/log/blob/main/wrap/slogwrap.go#L105>)
+## func [ToSlogHandler](<https://github.com/go-coldbrew/log/blob/main/wrap/slogwrap.go#L107>)
 
 ```go
 func ToSlogHandler(l log.Logger) slog.Handler
@@ -41,7 +41,7 @@ func ToSlogHandler(l log.Logger) slog.Handler
 ToSlogHandler wraps a ColdBrew log.Logger as an slog.Handler.
 
 <a name="ToSlogLogger"></a>
-## func [ToSlogLogger](<https://github.com/go-coldbrew/log/blob/main/wrap/slogwrap.go#L110>)
+## func [ToSlogLogger](<https://github.com/go-coldbrew/log/blob/main/wrap/slogwrap.go#L112>)
 
 ```go
 func ToSlogLogger(l log.Logger) *slog.Logger


### PR DESCRIPTION
## Summary
- `LogFields` now wraps `*options.Options` instead of owning its own `sync.RWMutex + map`
- `AddToLogContext`/`FromContext` delegate to `options.AddToLogFields`/`options.LogFieldsFromContext`
- Log fields are stored in the same `RequestContext` as options — one `context.WithValue` instead of two
- `Range()` calls `RangeSlice()` to preserve slice-snapshot iteration behavior
- Removed unused `newLogFields()`, legacy context key, and `sync` import

**Depends on:** go-coldbrew/options#17 (must be merged and tagged first)

**Note:** `go.mod` contains a temporary `replace` directive for local development. This will be removed and the options version bumped once options#17 is tagged.

## Test plan
- [x] All `log` tests pass (`log`, `loggers/slog`, `wrap`, all backend examples)
- [x] `make lint` passes (0 issues)
- [x] Benchmarks show no regression
- [x] Downstream packages verified locally: `errors`, `interceptors`, `core`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new methods to `LogFields` for sync.Map-compatible operations: `Delete`, `Load`, `Range`, and `Store`.

* **Documentation**
  * Updated logging documentation with clarified behavior for handling nil contexts and LogFields storage mechanism.
  * Updated generated API documentation links.

* **Chores**
  * Updated module dependency configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->