### PR TITLE
perf: cache caller info by program counter in slog backend

### DIFF
--- a/loggers/slog/slog.go
+++ b/loggers/slog/slog.go
@@ -7,6 +7,8 @@ import (
 	"log/slog"
 	"os"
 	"runtime"
+	"strconv"
+	"sync"
 	"time"
 
 	"github.com/go-coldbrew/log/loggers"
@@ -17,9 +19,10 @@ import (
 type slogBackendKey struct{}
 
 type logger struct {
-	handler  slog.Handler
-	levelVar *slog.LevelVar
-	opt      loggers.Options
+	handler     slog.Handler
+	levelVar    *slog.LevelVar
+	opt         loggers.Options
+	callerCache sync.Map // pc (uintptr) → "file:line" (string)
 }
 
 func stringKey(v any) string {
@@ -85,13 +88,17 @@ func (l *logger) Log(ctx context.Context, level loggers.Level, skip int, args ..
 		}
 	}
 
+	// Capture PC early — used for both caller info cache and slog.Record.
+	var pcs [1]uintptr
+	runtime.Callers(skip+2, pcs[:])
+
 	// Stack-allocated buffer avoids heap allocation for <=8 attrs (common case).
 	var attrBuf [8]slog.Attr
 	attrs := attrBuf[:0]
 
 	if l.opt.CallerInfo {
-		_, file, line := loggers.FetchCallerInfo(skip+1, l.opt.CallerFileDepth)
-		attrs = append(attrs, slog.String(l.opt.CallerFieldName, fmt.Sprintf("%s:%d", file, line)))
+		callerStr := l.cachedCallerInfo(pcs[0], skip+1)
+		attrs = append(attrs, slog.String(l.opt.CallerFieldName, callerStr))
 	}
 
 	ctxFields := loggers.FromContext(ctx)
@@ -113,12 +120,23 @@ func (l *logger) Log(ctx context.Context, level loggers.Level, skip int, args ..
 		attrs = append(attrs, slog.Any("!BADKEY", args[len(args)-1]))
 	}
 
-	var pcs [1]uintptr
-	runtime.Callers(skip+2, pcs[:])
 	record := slog.NewRecord(time.Now(), slogLevel, msg, pcs[0])
 	record.AddAttrs(attrs...)
 
 	_ = l.handler.Handle(ctx, record)
+}
+
+// cachedCallerInfo returns a "file:line" string for the given program counter,
+// using a per-logger cache to avoid repeated runtime.FuncForPC, path trimming,
+// and string formatting for the same call site.
+func (l *logger) cachedCallerInfo(pc uintptr, skip int) string {
+	if v, ok := l.callerCache.Load(pc); ok {
+		return v.(string)
+	}
+	_, file, line := loggers.FetchCallerInfo(skip+1, l.opt.CallerFileDepth)
+	s := file + ":" + strconv.Itoa(line)
+	l.callerCache.Store(pc, s)
+	return s
 }
 
 func (l *logger) SetLevel(level loggers.Level) {

--- a/loggers/slog/slog.go
+++ b/loggers/slog/slog.go
@@ -97,7 +97,7 @@ func (l *logger) Log(ctx context.Context, level loggers.Level, skip int, args ..
 	attrs := attrBuf[:0]
 
 	if l.opt.CallerInfo {
-		callerStr := l.cachedCallerInfo(pcs[0], skip+1)
+		callerStr := l.cachedCallerInfo(pcs[0])
 		attrs = append(attrs, slog.String(l.opt.CallerFieldName, callerStr))
 	}
 
@@ -127,15 +127,33 @@ func (l *logger) Log(ctx context.Context, level loggers.Level, skip int, args ..
 }
 
 // cachedCallerInfo returns a "file:line" string for the given program counter,
-// using a per-logger cache to avoid repeated runtime.FuncForPC, path trimming,
-// and string formatting for the same call site.
-func (l *logger) cachedCallerInfo(pc uintptr, skip int) string {
+// using a per-logger cache to avoid repeated frame resolution and string
+// formatting for the same call site. The cache is bounded by the number of
+// unique log call sites in the binary (typically hundreds).
+func (l *logger) cachedCallerInfo(pc uintptr) string {
 	if v, ok := l.callerCache.Load(pc); ok {
 		return v.(string)
 	}
-	_, file, line := loggers.FetchCallerInfo(skip+1, l.opt.CallerFileDepth)
-	s := file + ":" + strconv.Itoa(line)
-	l.callerCache.Store(pc, s)
+	// Derive file:line from the pc we already captured for slog.Record,
+	// avoiding a redundant runtime.Caller call.
+	frames := runtime.CallersFrames([]uintptr{pc})
+	f, _ := frames.Next()
+	file := f.File
+	depth := l.opt.CallerFileDepth
+	if depth <= 0 {
+		depth = 2
+	}
+	for i := len(file) - 1; i > 0; i-- {
+		if file[i] == '/' {
+			depth--
+			if depth == 0 {
+				file = file[i+1:]
+				break
+			}
+		}
+	}
+	s := file + ":" + strconv.Itoa(f.Line)
+	l.callerCache.LoadOrStore(pc, s)
 	return s
 }
 


### PR DESCRIPTION
## Summary
- Adds callerCache sync.Map to the slog logger struct, keyed by program counter
- After warmup, FetchCallerInfo + path trimming + FuncForPC + string formatting are all skipped
- Consolidates runtime.Callers call with the one already needed for slog.Record
- Replaces fmt.Sprintf with string concat for the initial build

CallerInfo is enabled by default, so this fires on every log call.

## Test plan
- [x] go test -race ./... passes (all backends)
- [x] make lint — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal logging performance through improved caller information resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->