### PR TITLE
feat: cap slog group nesting depth at 10 levels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-coldbrew/log
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/go-coldbrew/options v0.3.0

--- a/wrap/slogwrap.go
+++ b/wrap/slogwrap.go
@@ -64,7 +64,7 @@ func (h *slogHandler) Handle(ctx context.Context, record slog.Record) error {
 
 	// Append record attrs with the current group prefix.
 	record.Attrs(func(a slog.Attr) bool {
-		args = appendAttr(args, h.groupPrefix, a)
+		args = appendAttr(args, h.groupPrefix, a, 0)
 		return true
 	})
 
@@ -80,7 +80,7 @@ func (h *slogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	// and won't be affected by future WithGroup calls.
 	var resolved []any
 	for _, a := range attrs {
-		resolved = appendAttr(resolved, h.groupPrefix, a)
+		resolved = appendAttr(resolved, h.groupPrefix, a, 0)
 	}
 	newPreformatted := make([]any, len(h.preformatted), len(h.preformatted)+len(resolved))
 	copy(newPreformatted, h.preformatted)
@@ -126,8 +126,14 @@ func fromSlogLevel(level slog.Level) loggers.Level {
 	}
 }
 
+// maxGroupDepth is the maximum nesting depth for slog group attributes.
+// Beyond this depth, groups are replaced with a placeholder to prevent
+// memory exhaustion from pathological input.
+const maxGroupDepth = 10
+
 // appendAttr flattens an slog.Attr into key-value pairs, applying a group prefix.
-func appendAttr(args []any, groupPrefix string, a slog.Attr) []any {
+// depth tracks the current group nesting level to cap unbounded recursion.
+func appendAttr(args []any, groupPrefix string, a slog.Attr, depth int) []any {
 	a.Value = a.Value.Resolve()
 	if a.Equal(slog.Attr{}) {
 		return args
@@ -139,13 +145,16 @@ func appendAttr(args []any, groupPrefix string, a slog.Attr) []any {
 	}
 
 	if a.Value.Kind() == slog.KindGroup {
+		if depth >= maxGroupDepth {
+			return append(args, key, "[nested group depth exceeded]")
+		}
 		groupAttrs := a.Value.Group()
 		innerPrefix := groupPrefix
 		if a.Key != "" {
 			innerPrefix = groupPrefix + a.Key + "."
 		}
 		for _, ga := range groupAttrs {
-			args = appendAttr(args, innerPrefix, ga)
+			args = appendAttr(args, innerPrefix, ga, depth+1)
 		}
 		return args
 	}

--- a/wrap/slogwrap.go
+++ b/wrap/slogwrap.go
@@ -131,6 +131,10 @@ func fromSlogLevel(level slog.Level) loggers.Level {
 // memory exhaustion from pathological input.
 const maxGroupDepth = 10
 
+// GroupDepthExceededPlaceholder is the value used when slog group nesting
+// exceeds maxGroupDepth.
+const GroupDepthExceededPlaceholder = "[nested group depth exceeded]"
+
 // appendAttr flattens an slog.Attr into key-value pairs, applying a group prefix.
 // depth tracks the current group nesting level to cap unbounded recursion.
 func appendAttr(args []any, groupPrefix string, a slog.Attr, depth int) []any {
@@ -146,7 +150,7 @@ func appendAttr(args []any, groupPrefix string, a slog.Attr, depth int) []any {
 
 	if a.Value.Kind() == slog.KindGroup {
 		if depth >= maxGroupDepth {
-			return append(args, key, "[nested group depth exceeded]")
+			return append(args, key, GroupDepthExceededPlaceholder)
 		}
 		groupAttrs := a.Value.Group()
 		innerPrefix := groupPrefix

--- a/wrap/slogwrap.go
+++ b/wrap/slogwrap.go
@@ -131,9 +131,9 @@ func fromSlogLevel(level slog.Level) loggers.Level {
 // memory exhaustion from pathological input.
 const maxGroupDepth = 10
 
-// GroupDepthExceededPlaceholder is the value used when slog group nesting
+// groupDepthExceededPlaceholder is the value used when slog group nesting
 // exceeds maxGroupDepth.
-const GroupDepthExceededPlaceholder = "[nested group depth exceeded]"
+const groupDepthExceededPlaceholder = "[nested group depth exceeded]"
 
 // appendAttr flattens an slog.Attr into key-value pairs, applying a group prefix.
 // depth tracks the current group nesting level to cap unbounded recursion.
@@ -150,7 +150,7 @@ func appendAttr(args []any, groupPrefix string, a slog.Attr, depth int) []any {
 
 	if a.Value.Kind() == slog.KindGroup {
 		if depth >= maxGroupDepth {
-			return append(args, key, GroupDepthExceededPlaceholder)
+			return append(args, key, groupDepthExceededPlaceholder)
 		}
 		groupAttrs := a.Value.Group()
 		innerPrefix := groupPrefix

--- a/wrap/slogwrap_test.go
+++ b/wrap/slogwrap_test.go
@@ -428,32 +428,28 @@ func TestAppendAttr_DeepNesting(t *testing.T) {
 	entry := cl.lastEntry()
 
 	// Groups beyond maxGroupDepth should be capped with the placeholder.
+	// The leaf value "deep" should NOT appear at all since it's beyond the cap.
 	foundPlaceholder := false
-	foundDeepLeaf := false
+	foundLeafValue := false
 	start := 0
 	if len(entry.Args)%2 != 0 {
 		start = 1
 	}
 	for i := start; i < len(entry.Args)-1; i += 2 {
 		v := fmt.Sprint(entry.Args[i+1])
-		if v == GroupDepthExceededPlaceholder {
+		if v == groupDepthExceededPlaceholder {
 			foundPlaceholder = true
 		}
 		if v == "deep" {
-			k := fmt.Sprint(entry.Args[i])
-			// Should NOT reach full depth
-			dots := strings.Count(k, ".")
-			if dots >= testDepth-1 {
-				foundDeepLeaf = true
-			}
+			foundLeafValue = true
 		}
 	}
 
 	if !foundPlaceholder {
 		t.Errorf("expected depth-exceeded placeholder in args, got: %v", entry.Args)
 	}
-	if foundDeepLeaf {
-		t.Errorf("should not have resolved all %d levels of nesting", testDepth)
+	if foundLeafValue {
+		t.Errorf("leaf value should not appear when nesting exceeds maxGroupDepth (%d), got: %v", maxGroupDepth, entry.Args)
 	}
 }
 

--- a/wrap/slogwrap_test.go
+++ b/wrap/slogwrap_test.go
@@ -408,6 +408,55 @@ func TestWithGroupThenWithAttrs(t *testing.T) {
 	}
 }
 
+func TestAppendAttr_DeepNesting(t *testing.T) {
+	cl, l := newCaptureLogger(loggers.DebugLevel)
+	h := ToSlogHandler(l)
+
+	// Build a 15-level deep nested group: g0.g1.g2...g14.leaf = "deep"
+	attr := slog.String("leaf", "deep")
+	for i := 14; i >= 0; i-- {
+		attr = slog.Group(fmt.Sprintf("g%d", i), attr)
+	}
+
+	var r slog.Record
+	r.Level = slog.LevelInfo
+	r.Message = "deep nesting test"
+	r.AddAttrs(attr)
+	_ = h.Handle(context.Background(), r)
+
+	entry := cl.lastEntry()
+
+	// Groups deeper than maxGroupDepth (10) should be capped with placeholder.
+	foundPlaceholder := false
+	foundDeepLeaf := false
+	start := 0
+	if len(entry.Args)%2 != 0 {
+		start = 1
+	}
+	for i := start; i < len(entry.Args)-1; i += 2 {
+		v := fmt.Sprint(entry.Args[i+1])
+		if v == "[nested group depth exceeded]" {
+			foundPlaceholder = true
+		}
+		// If nesting worked past depth 10, we'd find "deep" at g0.g1...g14.leaf
+		if v == "deep" {
+			k := fmt.Sprint(entry.Args[i])
+			// Count the dots to verify depth — should NOT reach 15 levels
+			dots := strings.Count(k, ".")
+			if dots >= 14 {
+				foundDeepLeaf = true
+			}
+		}
+	}
+
+	if !foundPlaceholder {
+		t.Errorf("expected depth-exceeded placeholder in args, got: %v", entry.Args)
+	}
+	if foundDeepLeaf {
+		t.Error("should not have resolved all 15 levels of nesting")
+	}
+}
+
 // TestReentryGuardIntegration verifies that having both the slog backend AND
 // the slog bridge active simultaneously does not cause an infinite loop.
 func TestReentryGuardIntegration(t *testing.T) {

--- a/wrap/slogwrap_test.go
+++ b/wrap/slogwrap_test.go
@@ -412,9 +412,10 @@ func TestAppendAttr_DeepNesting(t *testing.T) {
 	cl, l := newCaptureLogger(loggers.DebugLevel)
 	h := ToSlogHandler(l)
 
-	// Build a 15-level deep nested group: g0.g1.g2...g14.leaf = "deep"
+	// Build nesting deeper than maxGroupDepth to verify the cap.
+	testDepth := maxGroupDepth + 5
 	attr := slog.String("leaf", "deep")
-	for i := 14; i >= 0; i-- {
+	for i := testDepth - 1; i >= 0; i-- {
 		attr = slog.Group(fmt.Sprintf("g%d", i), attr)
 	}
 
@@ -426,7 +427,7 @@ func TestAppendAttr_DeepNesting(t *testing.T) {
 
 	entry := cl.lastEntry()
 
-	// Groups deeper than maxGroupDepth (10) should be capped with placeholder.
+	// Groups beyond maxGroupDepth should be capped with the placeholder.
 	foundPlaceholder := false
 	foundDeepLeaf := false
 	start := 0
@@ -435,15 +436,14 @@ func TestAppendAttr_DeepNesting(t *testing.T) {
 	}
 	for i := start; i < len(entry.Args)-1; i += 2 {
 		v := fmt.Sprint(entry.Args[i+1])
-		if v == "[nested group depth exceeded]" {
+		if v == GroupDepthExceededPlaceholder {
 			foundPlaceholder = true
 		}
-		// If nesting worked past depth 10, we'd find "deep" at g0.g1...g14.leaf
 		if v == "deep" {
 			k := fmt.Sprint(entry.Args[i])
-			// Count the dots to verify depth — should NOT reach 15 levels
+			// Should NOT reach full depth
 			dots := strings.Count(k, ".")
-			if dots >= 14 {
+			if dots >= testDepth-1 {
 				foundDeepLeaf = true
 			}
 		}
@@ -453,7 +453,7 @@ func TestAppendAttr_DeepNesting(t *testing.T) {
 		t.Errorf("expected depth-exceeded placeholder in args, got: %v", entry.Args)
 	}
 	if foundDeepLeaf {
-		t.Error("should not have resolved all 15 levels of nesting")
+		t.Errorf("should not have resolved all %d levels of nesting", testDepth)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add depth parameter to `appendAttr()` to prevent unbounded recursion from pathological nested slog group attributes
- Groups beyond depth 10 are replaced with `[nested group depth exceeded]` placeholder
- Addresses ROADMAP item 2.4

## Test plan
- [x] `TestAppendAttr_DeepNesting` verifies 15-level nesting is capped at 10
- [x] All existing slog bridge tests pass
- [x] `make test` and `make lint` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a cap on nested log attribute expansion; overly deep groups are replaced with a placeholder "[nested group depth exceeded]" to avoid infinite recursion and processing issues.

* **Tests**
  * Added coverage for extreme nesting to validate the depth limit and placeholder behavior.

* **Chores**
  * Updated Go toolchain directive to 1.25.9.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->